### PR TITLE
fix(yundownload): increase timeout period to enhance stability

### DIFF
--- a/test/test.py
+++ b/test/test.py
@@ -36,8 +36,8 @@ def gzip_check(filepath: Path):
 
 def main():
     yun = YunDownloader(
-        url='https://ftp.ebi.ac.uk/pub/databases/RNAcentral/releases/24.0/go_annotations/rnacentral_rfam_annotations.tsv.gz',
-        save_path='./data/rnacentral_rfam_annotations.tsv.gz',
+        url='https://down.360safe.com/se/360aibrowser1.1.1108.64.exe',
+        save_path='./data/360aibrowser1.1.1108.64.exe',
         limit=Limit(
             max_concurrency=8,
             max_join=16

--- a/yundownload/_cli.py
+++ b/yundownload/_cli.py
@@ -8,7 +8,7 @@ def cli():
     parser.add_argument('save_path', type=str, help='Save path, including file name')
     parser.add_argument('-mc', '--max_concurrency', default=4, type=int, help='Maximum concurrency')
     parser.add_argument('-mj', '--max_join', type=int, default=16, help='Maximum connection number')
-    parser.add_argument('-t', '--timeout', type=int, default=20, help='Timeout period')
+    parser.add_argument('-t', '--timeout', type=int, default=100, help='Timeout period')
     parser.add_argument('-r', '--retry', type=int, default=0, help='Retry times')
     parser.add_argument('--stream', action='store_true', default=False, help='Forced streaming')
 


### PR DESCRIPTION
The timeout period for downloads has been increased from 20 to 100 seconds toimprove the reliability of the download process. This adjustment helps prevent abrupt terminations due to network latency or server response time issues.

Additionally, updated the test file (`test.py`) to point to a new URL, reflecting a change in the testing infrastructure and ensuring that tests utilize a more stable and accessible resource.

BREAKING CHANGE: The increased timeout may affect users who rely on the previous timeout setting. Users should adjust their configurations accordingly if the default timeout period is no longer suitable for their use case.