### PR TITLE
feat(yundownload): add CLI progress bar and improve logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,10 @@ options:
 ```
 
 # Update log
+- V 0.1.23
+  - Remove the default log display and add a progress bar to the command line tool
+- V 0.1.22
+  - Fixed exception handling of sharding download
 - V 0.1.21
   - Repair download failure displays complete
 - V 0.1.20

--- a/poetry.lock
+++ b/poetry.lock
@@ -34,6 +34,17 @@ files = [
 ]
 
 [[package]]
+name = "colorama"
+version = "0.4.6"
+description = "Cross-platform colored terminal text."
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
+files = [
+    {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
+    {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
+]
+
+[[package]]
 name = "exceptiongroup"
 version = "1.2.1"
 description = "Backport of PEP 654 (exception groups)"
@@ -126,6 +137,26 @@ files = [
 ]
 
 [[package]]
+name = "tqdm"
+version = "4.66.4"
+description = "Fast, Extensible Progress Meter"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "tqdm-4.66.4-py3-none-any.whl", hash = "sha256:b75ca56b413b030bc3f00af51fd2c1a1a5eac6a0c1cca83cbb37a5c52abce644"},
+    {file = "tqdm-4.66.4.tar.gz", hash = "sha256:e4d936c9de8727928f3be6079590e97d9abfe8d39a590be678eb5919ffc186bb"},
+]
+
+[package.dependencies]
+colorama = {version = "*", markers = "platform_system == \"Windows\""}
+
+[package.extras]
+dev = ["pytest (>=6)", "pytest-cov", "pytest-timeout", "pytest-xdist"]
+notebook = ["ipywidgets (>=6)"]
+slack = ["slack-sdk"]
+telegram = ["requests"]
+
+[[package]]
 name = "typing-extensions"
 version = "4.12.2"
 description = "Backported and Experimental Type Hints for Python 3.8+"
@@ -139,4 +170,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "cef7f515ce9cb29f4735c8024abe9074a8ef527febe4a33e16bb93e6b25d69e6"
+content-hash = "3e1d07ff783b4a3a923b3728296b2e4ef283714ef988ae7d6b3096bc613b2a79"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "yundownload"
-version = "0.2.1"
+version = "0.2.3"
 description = "file downloader"
 authors = ["yunhai <bybxbwg@foxmail.com>"]
 license = "MIT"
@@ -11,6 +11,7 @@ python = "^3.10"
 httpx = "^0.27.0"
 
 
+tqdm = "^4.66.4"
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"

--- a/test/test.py
+++ b/test/test.py
@@ -3,7 +3,16 @@ import gzip
 from yundownload import YunDownloader, Limit
 from hashlib import sha256, md5
 from pathlib import Path
+import logging
 
+# logging.basicConfig(
+#     level=logging.INFO,
+#     format="[%(asctime)s] <%(name)s> [%(levelname)s] %(message)s",
+#     datefmt="%Y-%m-%d %H:%M:%S",
+#     handlers=[
+#         logging.StreamHandler(),
+#     ],
+# )
 
 def file2sha256(path: Path):
     sha = sha256()
@@ -36,18 +45,18 @@ def gzip_check(filepath: Path):
 
 def main():
     yun = YunDownloader(
-        url='https://down.360safe.com/se/360aibrowser1.1.1108.64.exe',
-        save_path='./data/360aibrowser1.1.1108.64.exe',
+        url='https://speed.cloudflare.com/__down?during=download&bytes=1073741824',
+        save_path='./data/data',
         limit=Limit(
             max_concurrency=8,
             max_join=16
         ),
-        stream=False
+        # stream=True
     )
     yun.DISTINGUISH_SIZE = 10 * 1024 * 1024
     yun.CHUNK_SIZE = 10 * 1024 * 1024
     yun.run()
-    gzip_check(Path('./data/rnacentral_rfam_annotations.tsv.gz'))
+    # gzip_check(Path('./data/rnacentral_rfam_annotations.tsv.gz'))
     # file2md5(Path('./data/rnacentral_species_specific_ids.fasta.gz'))
 
 

--- a/yundownload/_cli.py
+++ b/yundownload/_cli.py
@@ -21,6 +21,7 @@ def cli():
             max_join=args.max_join,
         ),
         timeout=args.timeout,
-        stream=args.stream
+        stream=args.stream,
+        cli=True
     )
     yun.run(error_retry=args.retry)


### PR DESCRIPTION
- Introduce a progress bar for the command line interface (CLI) to enhance user experience during downloads.
- Remove default logging configuration and streamline logging outputs for cleaner logs.
- Refactor code to distinguish between new downloads and resuming existing ones, ensuring proper handling of incomplete downloads due to network issues.
- Increase timeout period to 100 seconds to improve download stability and reliability.
- Update test file (`test.py`) with a new URL to reflect changes in the testing infrastructure.

BREAKING CHANGE: The increased timeout and modified internal method names may affect users who rely on the previous settings or call the internal methods directly.