### PR TITLE
feat(yundownload): add CLI progress bar and improve logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,12 @@ options:
 ```
 
 # Update log
+
+- V 0.1.24
+  - Add the auth parameter to carry identity information
+  - You can add the max_redirects parameter to limit the number of redirects
+  - Add the retries parameter to specify the number of request tries
+  - Add the verify parameter to specify whether to verify the SSL certificate
 - V 0.1.23
   - Remove the default log display and add a progress bar to the command line tool
 - V 0.1.22

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "yundownload"
-version = "0.2.3"
+version = "0.2.4"
 description = "file downloader"
 authors = ["yunhai <bybxbwg@foxmail.com>"]
 license = "MIT"


### PR DESCRIPTION
- Introduce a progress bar for the command line interface (CLI) to enhance user experience during downloads.
- Remove default logging configuration and streamline logging outputs for cleaner logs.
- Refactor code to distinguish between new downloads and resuming existing ones, ensuring proper handling of incomplete downloads due to network issues.
- Increase timeout period to 100 seconds to improve download stability and reliability.
- Update test file (`test.py`) with a new URL to reflect changes in the testing infrastructure.

BREAKING CHANGE: The increased timeout and modified internal method names may affect users who rely on the previous settings or call the internal methods directly.