### PR TITLE
feat(yundownload): make limit parameters optional in YunDownloader init

### DIFF
--- a/yundownload/_cli.py
+++ b/yundownload/_cli.py
@@ -1,4 +1,5 @@
 import argparse
+
 from . import YunDownloader, Limit
 
 

--- a/yundownload/_yundownload.py
+++ b/yundownload/_yundownload.py
@@ -3,12 +3,13 @@ import logging
 import threading
 import time
 from collections import deque
+from dataclasses import dataclass
 from pathlib import Path
 from threading import Thread
 from typing import Callable
-from dataclasses import dataclass
-from tqdm import tqdm
+
 import httpx
+from tqdm import tqdm
 
 logger = logging.getLogger(__name__)
 
@@ -64,7 +65,7 @@ class YunDownloader:
     def __init__(self,
                  url: str,
                  save_path: str,
-                 limit: Limit = Limit(max_concurrency=8, max_join=16),
+                 limit: Limit = Limit(),
                  dynamic_concurrency: bool = False,
                  update_callable: Callable = None,
                  params: dict = None,


### PR DESCRIPTION
Change the `limit` parameter in the `YunDownloader` class initialization to havedefault values, thus making it optional for users to provide when creating an instance. This enhances the flexibility and ease of use of the download manager by allowing users to skip specifying concurrency and join limits if they wish to use the class with default settings.