### PR TITLE
feat(github-actions): add commit and push version bump

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -44,12 +44,7 @@ jobs:
           # 将新版本号保存为环境变量，用于后续操作
           echo "NEW_VERSION=$NEW_VERSION" >> $GITHUB_ENV
 
-      - name: Commit and push version bump
-        run: |
-          git config --local user.email "action@github.com"
-          git config --local user.name "GitHub Action"
-          git commit -am "Bump version to $NEW_VERSION [skip ci]"
-          git push origin HEAD:master
+
 
       - name: Install dependencies
         run: |
@@ -79,6 +74,10 @@ jobs:
         run: |
           poetry config pypi-token.pypi ${{ secrets.PYPI_API_TOKEN }}
 
+      - name: print pypi api token
+        run: |
+          echo "PYPI_API_TOKEN=${{ secrets.PYPI_API_TOKEN }}"
+
       - name: Publish to PyPI
         if: github.event_name != 'pull_request'
         run: |
@@ -94,3 +93,10 @@ jobs:
           asset_path: ./dist/naive-${{ env.NEW_VERSION }}-py3-none-any.whl
           asset_name: naive-${{ env.NEW_VERSION }}-py3-none-any.whl
           asset_content_type: application/zip
+
+      - name: Commit and push version bump
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git commit -am "Bump version to $NEW_VERSION [skip ci]"
+          git push origin HEAD:master


### PR DESCRIPTION
Add a new step in the GitHub Actions workflow to commit and push the version bump to the remote repository. This automation helps in keeping the version control system up-to-date with the latest package versions.

The step includes configuring local Git settings for the action and committing with a message that indicates the version bump. It is intended to run after the version bumping process