### PR TITLE
feat(github-actions): add commit and push version bump

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -14,6 +14,8 @@ permissions:
 jobs:
   build-and-release:
     runs-on: ubuntu-latest
+    environment:
+      name: PYPI
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Add a new step in the GitHub Actions workflow to commit and push the version bump to the remote repository. This automation helps in keeping the version control system up-to-date with the latest package versions.

The step includes configuring local Git settings for the action and committing with a message that indicates the version bump. It is intended to run after the version bumping process