### PR TITLE
feat(github-actions): add commit and push version bump

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -102,5 +102,6 @@ jobs:
         run: |
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
+          git checkout main
           git commit -am "Bump version to $NEW_VERSION [skip ci]"
-          git push origin main
+          git push origin HEAD:main


### PR DESCRIPTION
Add a new step in the GitHub Actions workflow to commit and push the version bump to the remote repository. This automation helps in keeping the version control system up-to-date with the latest package versions.

The step includes configuring local Git settings for the action and committing with a message that indicates the version bump. It is intended to run after the version bumping process