### PR TITLE
fix(yundownload): adjust chunk sizes for improved download efficiency

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ options:
 
 # Update log
 
+- V 0.2.7
+  - Fix known bugs
 - V 0.2.6
   - None Example Change the asynchronous writing of files in fragment download
 - V 0.2.5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "yundownload"
-version = "0.2.6"
+version = "0.2.7"
 description = "file downloader"
 authors = ["yunhai <bybxbwg@foxmail.com>"]
 license = "MIT"

--- a/yundownload/_yundownload.py
+++ b/yundownload/_yundownload.py
@@ -62,6 +62,7 @@ class YunDownloader:
     CHUNK_SIZE = 100 * 1024 * 1024
     HEARTBEAT_SLEEP = 5
     DISTINGUISH_SIZE = 500 * 1024 * 1024
+    STREAM_SIZE = 1 * 1024 * 1024
 
     def __init__(self,
                  url: str,
@@ -175,7 +176,7 @@ class YunDownloader:
             try:
                 res.raise_for_status()
                 async with aiofiles.open(save_path, 'ab') as f:
-                    async for chunk in res.aiter_bytes(chunk_size=2048):
+                    async for chunk in res.aiter_bytes(chunk_size=self.STREAM_SIZE):
                         await f.write(chunk)
                         res: httpx.Response
                         self.download_count += len(chunk)
@@ -281,7 +282,7 @@ class YunDownloader:
                 try:
                     res.raise_for_status()
                     with self.save_path.open('ab+') as f:
-                        for chunk in res.iter_bytes(chunk_size=2048):
+                        for chunk in res.iter_bytes(chunk_size=self.STREAM_SIZE):
                             f.write(chunk)
                             self.download_count += len(chunk)
                     logger.info(f'{self.save_path} stream download success')


### PR DESCRIPTION
Increase the STREAM_SIZE in the YunDownloader class to1MB to enhance the asynchronous writing of files during downloads. This change ensures that the downloads are processed more efficiently with larger chunks.

Additionally, update the version in pyproject.toml to 0.2.7 to reflect the codebase changes. The README is also updated to document the bug fixes in this version.