### PR TITLE
fix(yundownload): refine semaphore handling and add large file warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ options:
 
 # Update log
 
+- V 0.2.8
+  - Fix known bugs and add warnings for subsequent optimization of large file shards
 - V 0.2.7
   - Fix known bugs
 - V 0.2.6


### PR DESCRIPTION
Refactor the __chunk_download method to acquire the semaphore from the instance rather than passing it as a parameter, simplifying the asynchronous chunk download logic. Additionally, introduce a warning when the file size exceeds 200 chunks to mitigate potential performance issues with large file downloads.

Update the README to document these changes and reflect the bug fixes in version 0.2.8.