### PR TITLE
fix(yundownload): refine semaphore handling and add large file warning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "yundownload"
-version = "0.2.7"
+version = "0.2.8"
 description = "file downloader"
 authors = ["yunhai <bybxbwg@foxmail.com>"]
 license = "MIT"


### PR DESCRIPTION
Refactor the __chunk_download method to acquire the semaphore from the instance rather than passing it as a parameter, simplifying the asynchronous chunk download logic. Additionally, introduce a warning when the file size exceeds 200 chunks to mitigate potential performance issues with large file downloads.

Update the README to document these changes and reflect the bug fixes in version 0.2.8.