### PR TITLE
fix(yundownload): enable follow_redirects and update version to 0.2.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ options:
 
 # Update log
 
+- V 0.2.9
+  - Fix known bugs
 - V 0.2.8
   - Fix known bugs and add warnings for subsequent optimization of large file shards
 - V 0.2.7

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "yundownload"
-version = "0.2.8"
+version = "0.2.9"
 description = "file downloader"
 authors = ["yunhai <bybxbwg@foxmail.com>"]
 license = "MIT"

--- a/test/test.py
+++ b/test/test.py
@@ -45,8 +45,8 @@ def gzip_check(filepath: Path):
 
 def main():
     yun = YunDownloader(
-        url='https://hgdownload2.soe.ucsc.edu/gbdb/mm9/bbi/wgEncodeCshlLongRnaSeqAdrenalAdult8wksAlnRep2V2.bam',
-        save_path='./data/wgEncodeCshlLongRnaSeqAdrenalAdult8wksAlnRep2V2.bam',
+        url='https://download.cncb.ac.cn/gwh/gwh.tar.gz',
+        save_path='./data/gwh.tar.gz',
         limit=Limit(
             max_concurrency=16,
             max_join=16

--- a/yundownload/_yundownload.py
+++ b/yundownload/_yundownload.py
@@ -263,6 +263,7 @@ class YunDownloader:
                 cookies=self.cookies,
                 auth=self.auth,
                 verify=self.verify,
+                follow_redirects=True,
                 transport=httpx.HTTPTransport(retries=self.retries),
                 max_redirects=self.max_redirects) as client:
             headers = {}


### PR DESCRIPTION
Enable the follow_redirects option in the httpx client configuration to handle automatic redirections. This enhancement improves the robustness of URL handling by allowing the client to follow redirects without explicit user intervention.

This commit also updates the pyproject.toml to bump the version to 0.2.9, as well as README to reflect the bug fixes and new feature additions.