### PR TITLE
fix(yundownload): ensure type compatibility for chunk_end in __chunk_…

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ options:
 ```
 
 # Update log
+- V 0.2.12
+  - Fixed a size issue with the last piece of the shard download file
 - V 0.2.11
   - Removes the compressed portion of the default request header
 - V 0.2.10

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "yundownload"
-version = "0.2.11"
+version = "0.2.12"
 description = "file downloader"
 authors = ["yunhai <bybxbwg@foxmail.com>"]
 license = "MIT"

--- a/yundownload/_yundownload.py
+++ b/yundownload/_yundownload.py
@@ -162,7 +162,7 @@ class YunDownloader:
         self.loop.close()
 
     async def __chunk_download(self, client: httpx.AsyncClient, chunk_start: int,
-                               chunk_end: int, save_path: Path):
+                               chunk_end: int | str, save_path: Path):
         await self.semaphore.acquire()
         headers = {'Range': f'bytes={chunk_start}-{chunk_end}'}
         if save_path.exists():
@@ -215,6 +215,7 @@ class YunDownloader:
                     f'{self.url} The file size exceeds the threshold of 200. Ensure the file server performance')
             for index, chunk_start in enumerate(range(0, self.content_length, self.CHUNK_SIZE)):
                 chunk_end = min(chunk_start + self.CHUNK_SIZE - 1, self.content_length)
+                if chunk_end == self.content_length: chunk_end = ''
                 save_path = self.save_path.parent / '{}--{}.distributeddownloader'.format(
                     self.save_path.stem, str(index).zfill(5))
                 logger.info(f'{self.url} slice download {index} {chunk_start} {chunk_end}')


### PR DESCRIPTION
…downloadThe type hint for the `chunk_end` parameter in the `__chunk_download` method

was updated to accept both `int` and `str`, aligning with the necessary flexibility for handling the edge case where `chunk_end` could be an empty string. This change ensures type compatibility and resolves potential issues with type checking.

Additionally, the project's `README.md` was updated to reflect the fixed issue in version 0.2.12, providing clarity on the changes made since version 0.2.11.