### PR TITLE
fix(yundownload): correct file name generation for distributed downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ options:
 ```
 
 # Update log
+- V 0.2.13
+  - Fixed multiple file fragment download file name issue
 - V 0.2.12
   - Fixed a size issue with the last piece of the shard download file
 - V 0.2.11

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "yundownload"
-version = "0.2.12"
+version = "0.2.13"
 description = "file downloader"
 authors = ["yunhai <bybxbwg@foxmail.com>"]
 license = "MIT"

--- a/test/test.py
+++ b/test/test.py
@@ -1,14 +1,4 @@
-import requests
+import warnings
 
-# proxy = '117.42.94.219:21472'
-proxy = '106.105.218.244:80'
-proxies = {
-    'http': 'http://' + proxy,
-    'https': 'http://' + proxy,
-}
-headers = {
-    'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.159 Safari/537.36'
-}
-r = requests.get('https://www.baidu.com/', proxies=proxies, headers=headers, timeout=5, verify=False)
-print(r.status_code)
-print(r.text)
+
+warnings.warn("尼玛的")

--- a/yundownload/_yundownload.py
+++ b/yundownload/_yundownload.py
@@ -217,7 +217,7 @@ class YunDownloader:
                 chunk_end = min(chunk_start + self.CHUNK_SIZE - 1, self.content_length)
                 if chunk_end == self.content_length: chunk_end = ''
                 save_path = self.save_path.parent / '{}--{}.distributeddownloader'.format(
-                    self.save_path.stem, str(index).zfill(5))
+                    self.save_path.name.replace('.', '-'), str(index).zfill(5))
                 logger.info(f'{self.url} slice download {index} {chunk_start} {chunk_end}')
                 tasks.append(self.loop.create_task(
                     self.__chunk_download(client, chunk_start, chunk_end, save_path)))


### PR DESCRIPTION
Resolve an issue where multiple file fragment downloads were incorrectlynamed, resulting in non-conforming file names. The file name generation logic has been corrected to replace dots with dashes in the stem of the save path to ensure consistency and validity of the generated file names.