### PR TITLE
Added support for version parameters and Wget request headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ yun.download(
 
 ```shell
 yundownload -h
-usage: yundownload [-h] [-mc MAX_CONCURRENCY] [-mj MAX_JOIN] [-t TIMEOUT] [-r RETRY] [--stream] url save_path
+usage: yundownload [-h] [-mc MAX_CONCURRENCY] [-mj MAX_JOIN] [-t TIMEOUT] [-r RETRY] [--stream] [--wget] [-V] url save_path
 
 Yun Downloader
 
@@ -69,10 +69,14 @@ options:
   -r RETRY, --retry RETRY
                         Retry times
   --stream              Forced streaming
+  --wget                Carry the wget request header
+  -V, --version         Show the version number and exit
 ```
 
 # Update log
-
+- V 0.3.1
+  - Added version attribute to the package. 
+    The command line tool wget parameter has also been added to give the request a default header
 - V 0.3.0
     - To optimize the performance of the code, need to pay attention to at the same time, in this version and later
       versions of the API changes, details please refer to

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,7 +10,7 @@
 
 ------
 
-[![PyPI version](https://badge.fury.io/py/yundownload.svg)](https://badge.fury.io/py/yundownload)
+[![PyPI version](https://img.shields.io/pypi/v/yundownload)](https://pypi.org/project/yundownload/)
 
 *Python 简易高效的文件下载器。*
 
@@ -26,8 +26,8 @@ Yun download 是 Python 3 的文件下载器，它提供流式下载和文件分
 
 ```shell
 >>> from yundownload import YunDownloader
->>> y = YunDownloader('https://bing.com', './bing.html')
->>> y.run()
+>>> y = YunDownloader()
+>>> y.download('https://bing.com', './bing.html')
 ```
 
 或者，使用命令行的方式：

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -21,3 +21,4 @@ plugins:
 # mkdocs gh-deploy 提交到git pages
 # pip install mkdocs
 # pip install mkdocs-material
+# pip install mkdocs-git-revision-date-localized-plugin

--- a/poetry.lock
+++ b/poetry.lock
@@ -35,13 +35,13 @@ trio = ["trio (>=0.23)"]
 
 [[package]]
 name = "certifi"
-version = "2024.6.2"
+version = "2024.8.30"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.6"
 files = [
-    {file = "certifi-2024.6.2-py3-none-any.whl", hash = "sha256:ddc6c8ce995e6987e7faf5e3f1b02b302836a0e5d98ece18392cb1a36c72ad56"},
-    {file = "certifi-2024.6.2.tar.gz", hash = "sha256:3cd43f1c6fa7dedc5899d69d3ad0398fd018ad1a17fba83ddaf78aa46c747516"},
+    {file = "certifi-2024.8.30-py3-none-any.whl", hash = "sha256:922820b53db7a7257ffbda3f597266d435245903d80737e34f8a45ff3e3230d8"},
+    {file = "certifi-2024.8.30.tar.gz", hash = "sha256:bec941d2aa8195e248a60b31ff9f0558284cf01a52591ceda73ea9afffd69fd9"},
 ]
 
 [[package]]
@@ -57,13 +57,13 @@ files = [
 
 [[package]]
 name = "exceptiongroup"
-version = "1.2.1"
+version = "1.2.2"
 description = "Backport of PEP 654 (exception groups)"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "exceptiongroup-1.2.1-py3-none-any.whl", hash = "sha256:5258b9ed329c5bbdd31a309f53cbfb0b155341807f6ff7606a1e801a891b29ad"},
-    {file = "exceptiongroup-1.2.1.tar.gz", hash = "sha256:a4785e48b045528f5bfe627b6ad554ff32def154f42372786903b7abcfe1aa16"},
+    {file = "exceptiongroup-1.2.2-py3-none-any.whl", hash = "sha256:3111b9d131c238bec2f8f516e123e14ba243563fb135d3fe885990585aa7795b"},
+    {file = "exceptiongroup-1.2.2.tar.gz", hash = "sha256:47c2edf7c6738fafb49fd34290706d1a1a2f4d1c6df275526b62cbb4aa5393cc"},
 ]
 
 [package.extras]
@@ -103,13 +103,13 @@ trio = ["trio (>=0.22.0,<0.26.0)"]
 
 [[package]]
 name = "httpx"
-version = "0.27.0"
+version = "0.27.2"
 description = "The next generation HTTP client."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "httpx-0.27.0-py3-none-any.whl", hash = "sha256:71d5465162c13681bff01ad59b2cc68dd838ea1f10e51574bac27103f00c91a5"},
-    {file = "httpx-0.27.0.tar.gz", hash = "sha256:a0cb88a46f32dc874e04ee956e4c2764aba2aa228f650b06788ba6bda2962ab5"},
+    {file = "httpx-0.27.2-py3-none-any.whl", hash = "sha256:7bb2708e112d8fdd7829cd4243970f0c223274051cb35ee80c03301ee29a3df0"},
+    {file = "httpx-0.27.2.tar.gz", hash = "sha256:f7c2be1d2f3c3c3160d441802406b206c2b76f5947b11115e6df10c6c65e66c2"},
 ]
 
 [package.dependencies]
@@ -124,16 +124,17 @@ brotli = ["brotli", "brotlicffi"]
 cli = ["click (==8.*)", "pygments (==2.*)", "rich (>=10,<14)"]
 http2 = ["h2 (>=3,<5)"]
 socks = ["socksio (==1.*)"]
+zstd = ["zstandard (>=0.18.0)"]
 
 [[package]]
 name = "idna"
-version = "3.7"
+version = "3.8"
 description = "Internationalized Domain Names in Applications (IDNA)"
 optional = false
-python-versions = ">=3.5"
+python-versions = ">=3.6"
 files = [
-    {file = "idna-3.7-py3-none-any.whl", hash = "sha256:82fee1fc78add43492d3a1898bfa6d8a904cc97d8427f683ed8e798d07761aa0"},
-    {file = "idna-3.7.tar.gz", hash = "sha256:028ff3aadf0609c1fd278d8ea3089299412a7a8b9bd005dd08b9f8285bcb5cfc"},
+    {file = "idna-3.8-py3-none-any.whl", hash = "sha256:050b4e5baadcd44d760cedbd2b8e639f2ff89bbc7a5730fcc662954303377aac"},
+    {file = "idna-3.8.tar.gz", hash = "sha256:d838c2c0ed6fced7693d5e8ab8e734d5f8fda53a039c0164afb0b82e771e3603"},
 ]
 
 [[package]]
@@ -149,13 +150,13 @@ files = [
 
 [[package]]
 name = "tqdm"
-version = "4.66.4"
+version = "4.66.5"
 description = "Fast, Extensible Progress Meter"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "tqdm-4.66.4-py3-none-any.whl", hash = "sha256:b75ca56b413b030bc3f00af51fd2c1a1a5eac6a0c1cca83cbb37a5c52abce644"},
-    {file = "tqdm-4.66.4.tar.gz", hash = "sha256:e4d936c9de8727928f3be6079590e97d9abfe8d39a590be678eb5919ffc186bb"},
+    {file = "tqdm-4.66.5-py3-none-any.whl", hash = "sha256:90279a3770753eafc9194a0364852159802111925aa30eb3f9d85b0e805ac7cd"},
+    {file = "tqdm-4.66.5.tar.gz", hash = "sha256:e1020aef2e5096702d8a025ac7d16b1577279c9d63f8375b63083e9a5f0fcbad"},
 ]
 
 [package.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "yundownload"
-version = "0.3.0"
+version = "0.3.1"
 description = "file downloader"
 authors = ["yunhai <bybxbwg@foxmail.com>"]
 license = "MIT"

--- a/test/test.py
+++ b/test/test.py
@@ -1,6 +1,6 @@
-from yundownload import YunDownloader
-
 import logging
+
+from yundownload import YunDownloader
 
 logger = logging.getLogger('yundownload')
 logger.setLevel(logging.INFO)
@@ -9,7 +9,6 @@ ch.setLevel(logging.INFO)
 formatter = logging.Formatter('%(asctime)s @ %(name)s - %(levelname)s - %(message)s')
 ch.setFormatter(formatter)
 logger.addHandler(ch)
-
 
 yun = YunDownloader(cli=True)
 

--- a/yundownload/__init__.py
+++ b/yundownload/__init__.py
@@ -1,2 +1,3 @@
 from ._yundownload import YunDownloader, Limit
 from ._cli import cli
+from ._version import __version__

--- a/yundownload/_cli.py
+++ b/yundownload/_cli.py
@@ -1,6 +1,7 @@
 import argparse
 
 from . import YunDownloader, Limit
+from ._version import __version__
 
 
 def cli():
@@ -12,11 +13,14 @@ def cli():
     parser.add_argument('-t', '--timeout', type=int, default=100, help='Timeout period')
     parser.add_argument('-r', '--retry', type=int, default=0, help='Retry times')
     parser.add_argument('--stream', action='store_true', default=False, help='Forced streaming')
+    parser.add_argument('--wget', action='store_true', default=False, help='Carry the wget request header')
+    parser.add_argument('-V', '--version', action='version', version=f'%(prog)s {__version__}',
+                        help='Show the version number and exit')
     parser.set_defaults(help=parser.print_help)
 
     args = parser.parse_args()
     yun = YunDownloader(
-
+        headers={'User-Agent': 'Wget/1.12 (linux-gnu)'} if args.wget else None,
         limit=Limit(
             max_concurrency=args.max_concurrency,
             max_join=args.max_join,

--- a/yundownload/_version.py
+++ b/yundownload/_version.py
@@ -1,0 +1,3 @@
+from importlib.metadata import version
+
+__version__ = version("yundownload")


### PR DESCRIPTION
A version parameter has been added to allow users to view the program version in the command-line tool. In addition, a new Wget header has been introduced to add a default Wget flag for HTTP requests. This update allows users to have clearer version information when using the tool, and to simulate Wget behavior by specifying parameters.